### PR TITLE
Ensure v1.0 version is listed in version dropdown

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -29,6 +29,8 @@ sections:
     local_product_version: '1.0'
     local_header_links: []
     local_header_version_list:
+      - url_prefix: https://docs.pivotal.io/build-service/1-0
+        display_name: v1.0
       - url_prefix: https://docs.pivotal.io/build-service/0-2-0
         display_name: v0.2.0
       - url_prefix: https://docs.pivotal.io/build-service/0-1-0


### PR DESCRIPTION
Ensure v1.0 version is listed in version dropdown
Issue: https://github.com/pivotal-cf/docs-build-service/issues/155